### PR TITLE
Add function to restore HUD sprites

### DIFF
--- a/src/interface.h
+++ b/src/interface.h
@@ -32,6 +32,8 @@ void hide_pattern_icons(void); // Hide all pattern icons
 void show_pattern_icon(u16 npattern, bool show, bool priority); // Show or hide the icon of a pattern spell
 void restore_sprites_visibility(SpriteState* states, u16 count); // Restore the visibility of sprites
 SpriteState* hide_all_sprites(u16* count); // Hide all sprites and save their state
+SpriteState* hide_interface_sprites(void); // Hide HUD sprites and save state
+void show_interface_sprites(SpriteState* states); // Restore HUD sprites
 void pause_screen(void); // Pause / State screen
 void show_pause_pattern_list(bool show, u8 active_pattern); // Show or hide pattern list (Pause screen)
 void show_note_in_pause_pattern_list(u8 npattern, u8 nnote, bool show); // Show one of the notes of a pattern in the pattern list (Pause screen)


### PR DESCRIPTION
## Summary
- add `show_interface_sprites()` to restore HUD sprites hidden during pause
- use new function when closing the pause screen
- store HUD sprite count internally instead of passing it around

## Testing
- `python3 -m py_compile add_texts_comments.py generate_texts.py`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684d14c12b58832facb303d25870110b