### PR TITLE
Fix hide spell thunder detection and animation

### DIFF
--- a/src/characters.c
+++ b/src/characters.c
@@ -386,7 +386,8 @@ void update_character_animations(void) {
         // If there's an active pattern in combat state, play magic animation
         // even if the character is not in PATTERN_EFFECT state (solo protagonista)
         if (chr == active_character &&
-            combat_state == COMBAT_STATE_PLAYER_EFFECT)
+            combat_state == COMBAT_STATE_PLAYER_EFFECT &&
+            combatContext.activePattern != PATTERN_HIDE)
         {
             if (obj_character[chr].animation != ANIM_MAGIC) {
                 anim_character(chr, ANIM_MAGIC);
@@ -416,7 +417,9 @@ void update_character_animations(void) {
                 }
                 break;
             case STATE_PATTERN_EFFECT:
-                if (obj_character[chr].animation != ANIM_MAGIC) {
+                if (chr == active_character && combatContext.activePattern == PATTERN_HIDE) {
+                    // Keep current animation (idle or walking) while hidden
+                } else if (obj_character[chr].animation != ANIM_MAGIC) {
                     anim_character(chr, ANIM_MAGIC);
                 }
                 break;

--- a/src/controller.c
+++ b/src/controller.c
@@ -55,10 +55,7 @@ void handle_movement(u16 joy_value)    // Process directional inputs and update 
 
     // Update the character's state and animation based on movement
     if (moved) {
-        // Don't change state if we're in PATTERN_EFFECT with HIDE
-        if (!(obj_character[active_character].state == STATE_PATTERN_EFFECT && combatContext.activePattern == PATTERN_HIDE)) {
-            obj_character[active_character].state = STATE_WALKING;
-        }
+        obj_character[active_character].state = STATE_WALKING;
     } else if (obj_character[active_character].state == STATE_WALKING) {
         obj_character[active_character].state = STATE_IDLE;
     }

--- a/src/patterns.c
+++ b/src/patterns.c
@@ -16,6 +16,14 @@ static bool    enemy_note_active[6] = { false }; // Active enemy notes (1-6: MI-
 PlayerPattern playerPatterns[MAX_PLAYER_PATTERNS];
 EnemyPattern enemyPatterns[MAX_ENEMIES][MAX_PATTERN_ENEMY];
 
+// Remember which enemy pattern was active when the player launched a spell
+static u16 last_enemy_pattern = PATTERN_ENEMY_NONE;
+
+u16 get_last_enemy_pattern(void)
+{
+    return last_enemy_pattern;
+}
+
 // ---------------------------------------------------------------------
 // Local helpers
 // ---------------------------------------------------------------------
@@ -179,6 +187,13 @@ void launch_player_pattern(u16 patternId)
     }
 
     if (try_counter_spell()) { reset_note_queue(); return; }
+
+    // Remember current enemy pattern, if any
+    if (combat_state == COMBAT_STATE_ENEMY_PLAYING ||
+        combat_state == COMBAT_STATE_ENEMY_EFFECT)
+        last_enemy_pattern = combatContext.activePattern;
+    else
+        last_enemy_pattern = PATTERN_ENEMY_NONE;
 
     // We are launching a pattern: Set combat and player context
     combatContext.activePattern = patternId;
@@ -591,6 +606,8 @@ void cancel_enemy_pattern(u8 enemyId)
     combatContext.enemyNoteIndex = 0;
     combatContext.enemyNoteTimer = 0;
     combatContext.effectTimer = 0;
+    last_enemy_pattern = PATTERN_ENEMY_NONE;
+    combat_state = COMBAT_STATE_IDLE;
 
     // Reset enemy state, if the enemy stil exists
     if (enemyId >= MAX_ENEMIES || !obj_enemy[enemyId].obj_character.active) {

--- a/src/patterns.h
+++ b/src/patterns.h
@@ -114,6 +114,8 @@ void pattern_enemy_clear_notes(void); // Clear all enemy notes
 void init_enemy_patterns(u8 enemyId); // Initialize enemy patterns for a specific enemy slot
 void cancel_enemy_pattern(u8 enemyId); // Reset enemy state after a pattern is finished
 
+u16 get_last_enemy_pattern(void); // Retrieve the enemy pattern active before player spell
+
 // Note validation
 u16 validate_pattern(const u8 notes[4], bool* reversed); // Cancel an enemy pattern (e.g. if the player counters it)
 

--- a/src/patterns/pattern_hide.c
+++ b/src/patterns/pattern_hide.c
@@ -7,9 +7,8 @@ void player_hide_launch(void)
 
     dprintf(2,"Hide spell launched");
 
-    // If an enemy thunder is active, cancel it and show a hint
-    if (combat_state == COMBAT_STATE_ENEMY_EFFECT &&
-        combatContext.activePattern == PATTERN_EN_THUNDER)
+    // If an enemy thunder was active, cancel it and show a hint
+    if (get_last_enemy_pattern() == PATTERN_EN_THUNDER)
     {
         dprintf(2,"Thunder spell cancelled by hide");
         cancelled_thunder = true;


### PR DESCRIPTION
## Summary
- track last enemy pattern before launching player spells
- cancel enemy patterns cleanly and restore combat state
- detect enemy thunder correctly when launching the hide spell
- maintain walking/idle animation during hide

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6850f2d58608832fbbf984576abd580a