### PR TITLE
Ensure enemy thunder pattern resets correctly

### DIFF
--- a/src/patterns.c
+++ b/src/patterns.c
@@ -541,12 +541,8 @@ bool update_enemy_pattern(u8 enemySlot)
             if (pat->update && pat->update(enemySlot))
             {
                 // Pattern effect ended
-                pat->rechargeFrames = pat->baseDuration; // Reset cooldown to baseDuration
-                combat_state = COMBAT_STATE_IDLE;
-
-                // Restore enemy to idle animation
-                SPR_setAnim(spr_enemy[enemySlot], ANIM_IDLE);
-
+                pat->rechargeFrames = pat->baseDuration; // Reset cooldown
+                cancel_enemy_pattern(enemySlot);          // Restore combat state
                 return true;
             }
             return false; // Pattern effect still running

--- a/src/patterns/pattern_en_thunder.c
+++ b/src/patterns/pattern_en_thunder.c
@@ -39,6 +39,7 @@ bool enemy_thunder_update(u8 enemyId)
     if (++combatContext.effectTimer >= duration)
     {
         PAL_setColor(PAL0_COL4, savedColor);  // restore sky
+        flashOn = false;                      // reset flash state
         SPR_setAnim(spr_enemy[enemyId], ANIM_IDLE);
         if (obj_character[active_character].state != STATE_HIT)
         {


### PR DESCRIPTION
## Summary
- reset combat state via `cancel_enemy_pattern` when enemy thunder ends
- reset flash flag at the end of thunder effect

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68540dd3d80c832fa1f1c7cf43678dc6