### PR TITLE
Fix enemy thunder cleanup and state handling

### DIFF
--- a/src/patterns.c
+++ b/src/patterns.c
@@ -294,25 +294,31 @@ bool pattern_player_add_note(u8 noteCode)
             play_player_pattern_sound(PATTERN_PLAYER_NONE); // play invalid sound
             combatContext.patternLockTimer = MIN_TIME_BETWEEN_PATTERNS;
             obj_character[active_character].state = STATE_IDLE; // reset player state
-            if (id != PATTERN_PLAYER_NONE) {
-                // If the pattern was valid but not usable right now
-                dprintf(2,"Pattern %d not usable right now", id);
-                set_idle(); // reset combat state´
+            if (id != PATTERN_PLAYER_NONE)
+            {
+                // Pattern was valid but unusable right now
+                dprintf(2, "Pattern %d not usable right now", id);
+                bool resume_enemy = (combatContext.activeEnemy != ENEMY_NONE);
+                set_idle();                    // reset combat state
                 show_or_hide_interface(false); // hide interface
 
                 // Default dialog is SYSTEM_DIALOG[0]
                 DialogItem* dialog = (DialogItem*) &dialogs[SYSTEM_DIALOG][SYSMSG_CANT_USE_PATTERN];  // (ES) "No puedo usar ese patrón|ahora mismo" - (EN) "I can't use that pattern|right now"
-                // If there's a Ghost and we've trying to launch a direct thunder spell, show specific message
+
+                // If there's a Ghost and we're trying to launch a direct thunder spell, show specific message
                 for (u8 i = 0; i < MAX_ENEMIES; i++)
                 {
-                    if (obj_enemy[i].class_id==ENEMY_CLS_WEAVERGHOST && id == PATTERN_THUNDER && rev == false)
+                    if (obj_enemy[i].class_id == ENEMY_CLS_WEAVERGHOST && id == PATTERN_THUNDER && !rev)
                     {
                         dialog = (DialogItem*) &dialogs[ACT1_DIALOG3][A1D3_THINK_BACKWARDS];
                         break; // No need to check other enemies
                     }
                 }
-                talk_dialog(dialog); // Show dialog message
-                show_or_hide_interface(true); // show interface again
+
+                talk_dialog(dialog);           // Show dialog message
+                show_or_hide_interface(true);  // show interface again
+                if (resume_enemy)
+                    combat_state = COMBAT_STATE_ENEMY_EFFECT; // resume enemy
             }
             return false; // invalid pattern
         }
@@ -541,12 +547,8 @@ bool update_enemy_pattern(u8 enemySlot)
             if (pat->update && pat->update(enemySlot))
             {
                 // Pattern effect ended
-                pat->rechargeFrames = pat->baseDuration; // Reset cooldown to baseDuration
-                combat_state = COMBAT_STATE_IDLE;
-
-                // Restore enemy to idle animation
-                SPR_setAnim(spr_enemy[enemySlot], ANIM_IDLE);
-
+                pat->rechargeFrames = pat->baseDuration; // Reset cooldown
+                cancel_enemy_pattern(enemySlot);          // Restore combat state
                 return true;
             }
             return false; // Pattern effect still running

--- a/src/patterns/pattern_en_thunder.c
+++ b/src/patterns/pattern_en_thunder.c
@@ -39,6 +39,7 @@ bool enemy_thunder_update(u8 enemyId)
     if (++combatContext.effectTimer >= duration)
     {
         PAL_setColor(PAL0_COL4, savedColor);  // restore sky
+        flashOn = false;                      // reset flash state
         SPR_setAnim(spr_enemy[enemyId], ANIM_IDLE);
         if (obj_character[active_character].state != STATE_HIT)
         {

--- a/src/patterns/pattern_thunder.c
+++ b/src/patterns/pattern_thunder.c
@@ -16,11 +16,16 @@ void player_thunder_launch(void)
         show_or_hide_interface(false); // Hide interface
         talk_dialog(&dialogs[ACT1_DIALOG3][A1D3_THINK_BACKWARDS]); // (ES) "Quizá deba pensar|al revés" - (EN) "I should maybe|think backwards"
         show_or_hide_interface(true);  // Show interface again
-        cancel_player_pattern(); // Cancel the pattern
+        reset_note_queue();            // clear notes without stopping enemy
+        combatContext.activePattern = PATTERN_PLAYER_NONE;
+        combatContext.patternReversed = false;
+        combatContext.patternLockTimer = 0;
+        obj_character[active_character].state = STATE_IDLE;
+        combat_state = COMBAT_STATE_ENEMY_EFFECT; // resume enemy effect
         return;
     }
 
-    // Save current CRAM entry so we can restore it later            */
+    // Save current CRAM entry so we can restore it later
     savedColor = PAL_getColor(PAL0_COL4); 
     dprintf(2, "Thunder: initial CRAM colour 0-4 = 0x%04X\n", savedColor);
 


### PR DESCRIPTION
## Summary
- handle invalid player patterns without stopping enemy effects
- restore palette correctly at the end of enemy thunder
- clean up comment and indentation

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68540dd3d80c832fa1f1c7cf43678dc6