### PR TITLE
Hide enemy notes during dialog

### DIFF
--- a/src/patterns.c
+++ b/src/patterns.c
@@ -179,7 +179,9 @@ void launch_player_pattern(u16 patternId)
     {
         dprintf(2,"Pattern %d not usable right now", patternId);
         show_or_hide_interface(false); // hide interface
+        hide_enemy_notes();
         talk_dialog(&dialogs[SYSTEM_DIALOG][SYSMSG_CANT_USE_PATTERN]); // (ES) "No puedo usar ese patrón|ahora mismo" - (EN) "I can't use that pattern|right now"
+        show_enemy_notes();
         if (interface_active==true) show_or_hide_interface(true); // show interface
         combatContext.patternLockTimer = MIN_TIME_BETWEEN_PATTERNS;
         set_idle(); // reset combat state
@@ -316,7 +318,9 @@ bool pattern_player_add_note(u8 noteCode)
                     }
                 }
 
+                hide_enemy_notes();
                 talk_dialog(dialog);           // Show dialog message
+                show_enemy_notes();
                 show_or_hide_interface(true);  // show interface again
                 if (resume_enemy) // If there's an enemy, resume its effect
                 {
@@ -460,6 +464,30 @@ void pattern_enemy_clear_notes(void)
             spr_enemy_rod[i] = NULL;
         }
         enemy_note_active[i] = false;
+    }
+}
+
+// Temporarily hide all active enemy note sprites
+void hide_enemy_notes(void)
+{
+    for (u8 i = 0; i < 6; ++i)
+    {
+        if (spr_enemy_rod[i] && enemy_note_active[i])
+        {
+            SPR_setVisibility(spr_enemy_rod[i], HIDDEN);
+        }
+    }
+}
+
+// Show again all active enemy note sprites
+void show_enemy_notes(void)
+{
+    for (u8 i = 0; i < 6; ++i)
+    {
+        if (spr_enemy_rod[i] && enemy_note_active[i])
+        {
+            SPR_setVisibility(spr_enemy_rod[i], VISIBLE);
+        }
     }
 }
 

--- a/src/patterns.h
+++ b/src/patterns.h
@@ -111,6 +111,8 @@ void launch_enemy_pattern(u8 enemySlot, u16 patternSlot); // Launch an enemy pat
 bool update_enemy_pattern(u8 enemySlot);      // Called every frame (true = finished)
 void pattern_enemy_add_note(u8 enemySlot, u8 noteCode); // Add a note to the enemy pattern
 void pattern_enemy_clear_notes(void); // Clear all enemy notes
+void hide_enemy_notes(void);          // Temporarily hide enemy note sprites
+void show_enemy_notes(void);          // Restore enemy note sprites
 void init_enemy_patterns(u8 enemyId); // Initialize enemy patterns for a specific enemy slot
 void cancel_enemy_pattern(u8 enemyId); // Reset enemy state after a pattern is finished
 


### PR DESCRIPTION
## Summary
- add ability to hide and restore enemy note sprites
- temporarily hide enemy notes when displaying "can't use pattern" dialogs

## Testing
- `python3 -m py_compile add_texts_comments.py generate_texts.py`

------
https://chatgpt.com/codex/tasks/task_e_6854508d91e4832f80e907c9266714b4