### PR TITLE
Fix collision resolution with subpixel movement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,7 @@ Las notas se codifican con constantes `NOTE_MI`…`NOTE_DO`. Jugador y enemigos 
 
 ### Entidades
 `Entity` incluye estado (`GameState`), posición, tamaño, prioridad, animación y datos de colisión. `characters`, `enemies` e `items` encapsulan este tipo para sus propias necesidades. Los enemigos además almacenan puntos de vida y un `EnemyMode` para distinguir sus fases.
+Desde esta actualización las entidades manejan coordenadas de tipo fijo (`fix16`) en `fx`/`fy` y una velocidad `velocity` expresada también en ese formato para permitir movimiento subpixel.
 
 ### Combate
 `combat.c` gestiona un bucle basado en `CombatState`. Durante `COMBAT_STATE_IDLE` los enemigos pueden lanzar patrones si su `rechargeFrames` ha terminado. El lanzamiento y actualización de patrones modifican `combat_state` y `combatContext` (temporizadores, notas en curso, enemigo activo…). Las funciones `hit_enemy` y `hit_player` aplican daño y activan la animación de `HURT`. `update_combat` se llama cada fotograma desde `next_frame` para avanzar la máquina de estados.

--- a/src/act_1.c
+++ b/src/act_1.c
@@ -272,7 +272,7 @@ void act_1_scene_5(void)    // Combat tutorial scene with pattern demonstrations
     active_character=CHR_linus;
     move_character_instant(CHR_linus, -30, 154);
     move_character_instant(CHR_clio, -30, 154);
-    follow_active_character(CHR_clio, true, 2);
+    follow_active_character(CHR_clio, true);
 
     // Initialize spells
     playerPatterns[PATTERN_THUNDER].enabled = true;

--- a/src/characters.c
+++ b/src/characters.c
@@ -232,8 +232,6 @@ void move_character(u16 nchar, s16 newx, s16 newy)    // Move character with wal
     }
 
     move_entity(&obj_character[nchar], spr_chr[nchar], newx, newy);
-    obj_character[nchar].fx = INT_TO_FIX16(obj_character[nchar].x);
-    obj_character[nchar].fy = INT_TO_FIX16(obj_character[nchar].y);
     obj_character[nchar].state=STATE_IDLE; // Set state to idle after moving
 }
 

--- a/src/characters.c
+++ b/src/characters.c
@@ -30,6 +30,7 @@ void init_character(u16 nchar)    // Create new character instance with sprites 
     u8 collision_y_offset=0;
     u8 collision_width=0;
     u8 collision_height=0;
+    f16 velocity = FIX16_ONE; // Default velocity for characters
     bool drops_shadow=true;
     const SpriteDefinition *nsprite = NULL;
     const SpriteDefinition *nsprite_shadow = NULL;
@@ -43,10 +44,12 @@ void init_character(u16 nchar)    // Create new character instance with sprites 
             if (player_has_rod) nsprite = &linus_sprite;
             else nsprite = &linus_norod_sprite;
             nsprite_shadow = &linus_shadow_sprite;
+            velocity = FIX16_ONE * 1.5 ; // Linus is faster
             break;
         case CHR_clio:
             nsprite = &clio_sprite;
             nsprite_shadow = &clio_shadow_sprite;
+            velocity = FIX16_ONE * 3 / 4; // Clio is slower
             break;
         case CHR_xander:
             nsprite = &xander_sprite;
@@ -73,9 +76,7 @@ void init_character(u16 nchar)    // Create new character instance with sprites 
             0, 0, INT_TO_FIX16(0), INT_TO_FIX16(0),
             x_size, y_size, npal, false, false, ANIM_IDLE, false,
             collision_x_offset, collision_y_offset, collision_width, collision_height,
-            STATE_IDLE, FALSE, INT_TO_FIX16(1), drops_shadow, 0 };
-        if (nchar == CHR_clio)
-            obj_character[nchar].velocity = (fix16)(FIX16_ONE * 3 / 4);
+            STATE_IDLE, FALSE, velocity, drops_shadow, 0 };
     } else {
         nsprite = obj_character[nchar].sd;
         nsprite_shadow = obj_character[nchar].sd_shadow;

--- a/src/characters.c
+++ b/src/characters.c
@@ -69,7 +69,13 @@ void init_character(u16 nchar)    // Create new character instance with sprites 
         if (collision_height==0) collision_height=2; // Two lines height
         if (collision_y_offset==0) collision_y_offset=y_size-1; // At the feet
 
-        obj_character[nchar] = (Entity) { true, nsprite, nsprite_shadow, 0, 0, x_size, y_size, npal, false, false, ANIM_IDLE, false, collision_x_offset, collision_y_offset, collision_width, collision_height, STATE_IDLE, FALSE, 0, drops_shadow, 0 };
+        obj_character[nchar] = (Entity) { true, nsprite, nsprite_shadow,
+            0, 0, INT_TO_FIX16(0), INT_TO_FIX16(0),
+            x_size, y_size, npal, false, false, ANIM_IDLE, false,
+            collision_x_offset, collision_y_offset, collision_width, collision_height,
+            STATE_IDLE, FALSE, INT_TO_FIX16(1), drops_shadow, 0 };
+        if (nchar == CHR_clio)
+            obj_character[nchar].velocity = (fix16)(FIX16_ONE * 3 / 4);
     } else {
         nsprite = obj_character[nchar].sd;
         nsprite_shadow = obj_character[nchar].sd_shadow;
@@ -143,7 +149,11 @@ void init_face(u16 nface)    // Create new character face sprite for dialogs
         default:
             return;
         }
-        obj_face[nface] = (Entity) { true, nsprite, NULL, 0, 160, 64, 64, npal, false, false, ANIM_IDLE, false, 0, 0, 0, 0, STATE_IDLE, FALSE, 0, false, 0 };
+        obj_face[nface] = (Entity) { true, nsprite, NULL,
+            0, 160, INT_TO_FIX16(0), INT_TO_FIX16(160),
+            64, 64, npal, false, false, ANIM_IDLE, false,
+            0, 0, 0, 0, STATE_IDLE, FALSE,
+            INT_TO_FIX16(1), false, 0 };
     } else {
         nsprite = obj_face[nface].sd;
         obj_face[nface].active=true;
@@ -221,6 +231,8 @@ void move_character(u16 nchar, s16 newx, s16 newy)    // Move character with wal
     }
 
     move_entity(&obj_character[nchar], spr_chr[nchar], newx, newy);
+    obj_character[nchar].fx = INT_TO_FIX16(obj_character[nchar].x);
+    obj_character[nchar].fy = INT_TO_FIX16(obj_character[nchar].y);
     obj_character[nchar].state=STATE_IDLE; // Set state to idle after moving
 }
 
@@ -231,6 +243,8 @@ void move_character_instant(u16 nchar,s16 x,s16 y)    // Set character position 
     SPR_setPosition(spr_chr[nchar], x, y);
     obj_character[nchar].x = x;
     obj_character[nchar].y = y;
+    obj_character[nchar].fx = INT_TO_FIX16(x);
+    obj_character[nchar].fy = INT_TO_FIX16(y);
     update_character_shadow(nchar);
     next_frame(false);
 }
@@ -267,10 +281,9 @@ void update_sprites_depth(void)    // Sort sprite layers based on Y position for
     }
 }
 
-void follow_active_character(u16 nchar, bool follow, u8 follow_speed)    // Set character to follow active character
+void follow_active_character(u16 nchar, bool follow)    // Set character to follow active character
 {
     obj_character[nchar].follows_character=follow;
-    obj_character[nchar].follow_speed=follow_speed;
     obj_character[nchar].state=STATE_IDLE;
     show_character(nchar, true);
 }
@@ -296,8 +309,6 @@ void approach_characters(void)    // Move NPCs that follow the hero
         if (!obj_character[nchar].active ||
             !obj_character[nchar].follows_character)               continue;
 
-        // Throttle by follow_speed
-        if (frame_counter % obj_character[nchar].follow_speed)     continue;
 
         dprintf(3,"Character %d is following\n", nchar);
 
@@ -311,10 +322,13 @@ void approach_characters(void)    // Move NPCs that follow the hero
              (obj_character[nchar].y +
               obj_character[nchar].y_size);
 
-        newx = obj_character[nchar].x +
-               (dx ? (dx > 0 ? 1 : -1) : 0);
-        newy = obj_character[nchar].y +
-               (dy ? (dy > 0 ? 1 : -1) : 0);
+        if (dx)
+            obj_character[nchar].fx += (dx > 0 ? obj_character[nchar].velocity : -obj_character[nchar].velocity);
+        if (dy)
+            obj_character[nchar].fy += (dy > 0 ? obj_character[nchar].velocity : -obj_character[nchar].velocity);
+
+        newx = FIX16_TO_INT(obj_character[nchar].fx);
+        newy = FIX16_TO_INT(obj_character[nchar].fy);
 
         // Distance to the active character if we accept the new position
         distance = char_distance(nchar, newx, newy, active_character);

--- a/src/characters.h
+++ b/src/characters.h
@@ -50,7 +50,7 @@ void move_character(u16 nchar, s16 x, s16 y); // Move a character to a new posit
 void move_character_instant(u16 nchar, s16 x, s16 y); // Move a character to a new position (instantly)
 void update_sprites_depth(void); // Update characters, items and enemies depth
 void update_character_shadow(u16 nchar); // Update shadow position for a character
-void follow_active_character(u16 nchar, bool follow, u8 follow_speed); // Follow (or unfollow active character)
+void follow_active_character(u16 nchar, bool follow); // Follow (or unfollow active character)
 void approach_characters(void); // Move characters with STATE_FOLLOWING towards the active character
 void reset_character_animations(void); // Reset all character animations to idle
 void update_character_animations(void); //Update the character's animation based on its current state

--- a/src/controller.c
+++ b/src/controller.c
@@ -69,8 +69,11 @@ void handle_character_movement(s16 dx, s16 dy)    // Update character position w
 
     s16 current_x = obj_character[active_character].x;
     s16 current_y = obj_character[active_character].y;
-    s16 new_x = current_x + dx;
-    s16 new_y = current_y + dy;
+
+    fix16 fx = obj_character[active_character].fx + FIX16_MUL(obj_character[active_character].velocity, INT_TO_FIX16(dx));
+    fix16 fy = obj_character[active_character].fy + FIX16_MUL(obj_character[active_character].velocity, INT_TO_FIX16(dy));
+    s16 new_x = FIX16_TO_INT(fx);
+    s16 new_y = FIX16_TO_INT(fy);
     u8 player_y_size = obj_character[active_character].y_size;
     bool direction_changed = false;
     bool scroll_user_mode =
@@ -148,6 +151,7 @@ void handle_character_movement(s16 dx, s16 dy)    // Update character position w
                  (new_x >= x_limit_min && new_x <= x_limit_max)) {
             // Update character position and flip state
             obj_character[active_character].x = new_x;
+            obj_character[active_character].fx = INT_TO_FIX16(new_x);
             if (direction_changed) {
                 obj_character[active_character].flipH = (dx < 0);
             }
@@ -160,6 +164,7 @@ void handle_character_movement(s16 dx, s16 dy)    // Update character position w
         if (new_y + player_y_size >= y_limit_min &&
             new_y + player_y_size <= y_limit_max) {
             obj_character[active_character].y = new_y;
+            obj_character[active_character].fy = INT_TO_FIX16(new_y);
             position_updated = true;
         }
     }
@@ -168,6 +173,8 @@ void handle_character_movement(s16 dx, s16 dy)    // Update character position w
     if (position_updated) {
         update_character(active_character);
     }
+    obj_character[active_character].fx = INT_TO_FIX16(obj_character[active_character].x);
+    obj_character[active_character].fy = INT_TO_FIX16(obj_character[active_character].y);
 }
 
 void handle_action_buttons(u16 joy_value)    // Process action buttons for item interaction and musical notes

--- a/src/controller.c
+++ b/src/controller.c
@@ -105,17 +105,23 @@ void handle_character_movement(s16 dx, s16 dy)    // Update character position w
         // If not changing direction, try moving in opposite direction
         s16 move_dx = direction_changed ? dx : -dx;
         s16 move_dy = direction_changed ? dy : -dy;
-        s16 test_x = direction_changed ? current_x : new_x;
-        s16 test_y = direction_changed ? current_y : new_y;
+        fix16 move_fx = INT_TO_FIX16(move_dx);
+        fix16 move_fy = INT_TO_FIX16(move_dy);
+        fix16 test_fx = direction_changed ? obj_character[active_character].fx : new_fx;
+        fix16 test_fy = direction_changed ? obj_character[active_character].fy : new_fy;
+        s16 test_x = FIX16_TO_INT(test_fx);
+        s16 test_y = FIX16_TO_INT(test_fy);
 
         // Move pixel by pixel until no collision or MAX_COLLISIONS reached
         while ((detect_char_enemy_collision(active_character, test_x, test_y) != ENEMY_NONE ||
                detect_char_item_collision(active_character, test_x, test_y) != ITEM_NONE ||
                detect_char_char_collision(active_character, test_x, test_y) != CHR_NONE) &&
                num_colls < MAX_COLLISIONS) {
-            
-            test_x += move_dx;
-            test_y += move_dy;
+
+            test_fx += move_fx;
+            test_fy += move_fy;
+            test_x = FIX16_TO_INT(test_fx);
+            test_y = FIX16_TO_INT(test_fy);
             num_colls++;
 
             // Stay within screen boundaries
@@ -129,12 +135,10 @@ void handle_character_movement(s16 dx, s16 dy)    // Update character position w
         }
 
         // Update new position to where we found no collision
-        new_x = test_x;
-        new_y = test_y;
-        fx = INT_TO_FIX16(new_x);
-        fy = INT_TO_FIX16(new_y);
-        new_fx = fx;
-        new_fy = fy;
+        new_fx = test_fx;
+        new_fy = test_fy;
+        new_x = FIX16_TO_INT(new_fx);
+        new_y = FIX16_TO_INT(new_fy);
     }
 
     bool position_updated = false;

--- a/src/controller.c
+++ b/src/controller.c
@@ -70,10 +70,16 @@ void handle_character_movement(s16 dx, s16 dy)    // Update character position w
     s16 current_x = obj_character[active_character].x;
     s16 current_y = obj_character[active_character].y;
 
-    fix16 fx = obj_character[active_character].fx + FIX16_MUL(obj_character[active_character].velocity, INT_TO_FIX16(dx));
-    fix16 fy = obj_character[active_character].fy + FIX16_MUL(obj_character[active_character].velocity, INT_TO_FIX16(dy));
+    fix16 fx = obj_character[active_character].fx +
+               FIX16_MUL(obj_character[active_character].velocity,
+                          INT_TO_FIX16(dx));
+    fix16 fy = obj_character[active_character].fy +
+               FIX16_MUL(obj_character[active_character].velocity,
+                          INT_TO_FIX16(dy));
     s16 new_x = FIX16_TO_INT(fx);
     s16 new_y = FIX16_TO_INT(fy);
+    fix16 new_fx = fx;
+    fix16 new_fy = fy;
     u8 player_y_size = obj_character[active_character].y_size;
     bool direction_changed = false;
     bool scroll_user_mode =
@@ -125,6 +131,10 @@ void handle_character_movement(s16 dx, s16 dy)    // Update character position w
         // Update new position to where we found no collision
         new_x = test_x;
         new_y = test_y;
+        fx = INT_TO_FIX16(new_x);
+        fy = INT_TO_FIX16(new_y);
+        new_fx = fx;
+        new_fy = fy;
     }
 
     bool position_updated = false;
@@ -151,7 +161,7 @@ void handle_character_movement(s16 dx, s16 dy)    // Update character position w
                  (new_x >= x_limit_min && new_x <= x_limit_max)) {
             // Update character position and flip state
             obj_character[active_character].x = new_x;
-            obj_character[active_character].fx = INT_TO_FIX16(new_x);
+            obj_character[active_character].fx = new_fx;
             if (direction_changed) {
                 obj_character[active_character].flipH = (dx < 0);
             }
@@ -164,7 +174,7 @@ void handle_character_movement(s16 dx, s16 dy)    // Update character position w
         if (new_y + player_y_size >= y_limit_min &&
             new_y + player_y_size <= y_limit_max) {
             obj_character[active_character].y = new_y;
-            obj_character[active_character].fy = INT_TO_FIX16(new_y);
+            obj_character[active_character].fy = new_fy;
             position_updated = true;
         }
     }
@@ -173,8 +183,8 @@ void handle_character_movement(s16 dx, s16 dy)    // Update character position w
     if (position_updated) {
         update_character(active_character);
     }
-    obj_character[active_character].fx = INT_TO_FIX16(obj_character[active_character].x);
-    obj_character[active_character].fy = INT_TO_FIX16(obj_character[active_character].y);
+    obj_character[active_character].fx = new_fx;
+    obj_character[active_character].fy = new_fy;
 }
 
 void handle_action_buttons(u16 joy_value)    // Process action buttons for item interaction and musical notes

--- a/src/enemies.c
+++ b/src/enemies.c
@@ -185,8 +185,6 @@ void move_enemy(u16 nenemy, s16 newx, s16 newy)    // Move enemy with walking an
 
     move_entity(&obj_enemy[nenemy].obj_character, spr_enemy[nenemy], newx, newy);
     update_enemy_shadow(nenemy);
-    obj_enemy[nenemy].obj_character.fx = INT_TO_FIX16(obj_enemy[nenemy].obj_character.x);
-    obj_enemy[nenemy].obj_character.fy = INT_TO_FIX16(obj_enemy[nenemy].obj_character.y);
 
     anim_enemy(nenemy, ANIM_IDLE);
 }

--- a/src/enemies.h
+++ b/src/enemies.h
@@ -27,7 +27,6 @@ typedef struct
 {
     u16 max_hitpoints;
     bool follows_character; // If true, the enemy will follow the character
-    u8 follow_speed;
     bool has_pattern[MAX_PATTERN_ENEMY]; // If true, the enemy has a particular pattern
 } Enemy_Class;
 extern Enemy_Class obj_enemy_class[MAX_ENEMY_CLASSES]; // Enemy class object

--- a/src/entity.c
+++ b/src/entity.c
@@ -52,5 +52,7 @@ void move_entity(Entity *entity, Sprite *sprite, s16 newx, s16 newy)    // Move 
         if (e2 > -abs(dx)) { err -= abs(dy); x += sx; }
         if (e2 < abs(dy)) { err += abs(dx); y += sy; }
     }
+    entity->fx = INT_TO_FIX16(entity->x);
+    entity->fy = INT_TO_FIX16(entity->y);
     movement_active=old_movement_active;
 }

--- a/src/entity.h
+++ b/src/entity.h
@@ -14,7 +14,7 @@ extern bool movement_active;
 // Fixed point helpers (10.6 format)
 #define FIX16_ONE       64
 #define INT_TO_FIX16(n) ((fix16)((n) << 6))
-#define FIX16_TO_INT(n) ((s16)((n) >> 6))
+#define FIX16_TO_INT(n) ((s16)((n) / FIX16_ONE))
 #define FIX16_MUL(a,b)  ((fix16)(((s32)(a) * (s32)(b)) >> 6))
 
 // Entities states

--- a/src/entity.h
+++ b/src/entity.h
@@ -11,6 +11,12 @@
 // Global variables
 extern bool movement_active;
 
+// Fixed point helpers (10.6 format)
+#define FIX16_ONE       64
+#define INT_TO_FIX16(n) ((fix16)((n) << 6))
+#define FIX16_TO_INT(n) ((s16)((n) >> 6))
+#define FIX16_MUL(a,b)  ((fix16)(((s32)(a) * (s32)(b)) >> 6))
+
 // Entities states
 typedef enum {
     STATE_IDLE,
@@ -33,6 +39,8 @@ typedef struct
     const SpriteDefinition  *sd_shadow;
     s16                     x;
     s16                     y;
+    fix16                   fx;
+    fix16                   fy;
     u8                      x_size;
     u8                      y_size;
     u16                     palette;
@@ -46,7 +54,7 @@ typedef struct
     u8                      collision_height;
     GameState               state;
     bool                    follows_character;
-    u8                      follow_speed;
+    fix16                   velocity;
     bool                    drops_shadow;
     u16                     modeTimer;
 } Entity;

--- a/src/items.c
+++ b/src/items.c
@@ -29,7 +29,11 @@ void init_item(u16 nitem, const SpriteDefinition *spritedef, u8 npal, u16 x_in_b
     obj_item[nitem].check_depth=check_depth;
 
     // We set X to 0, as we are gonna calc it later
-    obj_item[nitem].entity = (Entity) { true, spritedef, NULL, 0, y, x_size, y_size, npal, false, false, ANIM_IDLE, true, collision_x_offset, collision_y_offset, collision_width, collision_height, STATE_IDLE, FALSE, 0, false, 0 };
+    obj_item[nitem].entity = (Entity) { true, spritedef, NULL,
+        0, y, INT_TO_FIX16(0), INT_TO_FIX16(y),
+        x_size, y_size, npal, false, false, ANIM_IDLE, true,
+        collision_x_offset, collision_y_offset, collision_width, collision_height,
+        STATE_IDLE, FALSE, INT_TO_FIX16(0), false, 0 };
     spr_item[nitem] = NULL;
 
     // Check visibility and load sprite if needed
@@ -106,6 +110,8 @@ void display_item_if_visible(u16 nitem)    // Show/hide item based on screen vis
     // Update final state
     obj_item[nitem].entity.visible = should_be_visible;
     obj_item[nitem].entity.x = x;
+    obj_item[nitem].entity.fx = INT_TO_FIX16(x);
+    obj_item[nitem].entity.fy = INT_TO_FIX16(obj_item[nitem].entity.y);
 }
 
 void check_items_visibility(void)    // Update visibility state of all active items


### PR DESCRIPTION
## Summary
- adjust collision resolution logic to account for fractional coordinates

## Testing
- `python3 -m py_compile add_texts_comments.py generate_texts.py`
- `gcc -fsyntax-only -Isrc -x c src/controller.c` *(fails: genesis.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_685d796debd0832fbee3dea209e984e8