### PR TITLE
Fix follower scroll sync and animation

### DIFF
--- a/src/background.c
+++ b/src/background.c
@@ -62,10 +62,13 @@ void scroll_background(s16 dx)    // Handle background scrolling when character 
                         {
                             obj_character[nchar].x -= dx;
                             obj_character[nchar].fx = INT_TO_FIX16(obj_character[nchar].x);
+                            obj_character[nchar].state = STATE_IDLE; // Stop walking animation
                             update_character(nchar);
                         }
                     }
                 }
+                // Keep protagonist coordinates in sync
+                obj_character[active_character].fx = INT_TO_FIX16(obj_character[active_character].x);
             }
         }
     }

--- a/src/characters.c
+++ b/src/characters.c
@@ -348,9 +348,11 @@ void approach_characters(void)    // Move NPCs that follow the hero
         {
             dprintf(3,"Character %d moving to (%d, %d)\n", nchar, newx, newy);
 
-            // Update entity position
+            // Update entity position and keep fixed coordinates in sync
             obj_character[nchar].x     = newx;
             obj_character[nchar].y     = newy;
+            obj_character[nchar].fx    = INT_TO_FIX16(newx);
+            obj_character[nchar].fy    = INT_TO_FIX16(newy);
             obj_character[nchar].flipH = (dx < 0);
 
             // Update sprite position and properties

--- a/src/controller.c
+++ b/src/controller.c
@@ -257,6 +257,9 @@ void wait_for_followers(s16 dx)
                 next_frame(true);
             }
             movement_active = old_movement;
+            // Re-sync protagonist fixed coordinates after waiting
+            obj_character[active_character].fx = INT_TO_FIX16(obj_character[active_character].x);
+            obj_character[active_character].fy = INT_TO_FIX16(obj_character[active_character].y);
             look_left(active_character, (dx < 0)); // Look back to the right if moving right
         break; // Wait for a single follower only
         }


### PR DESCRIPTION
## Summary
- keep characters in idle state when moved by scrolling
- ensure follower fix16 coordinates sync with integer position
- reset protagonist fix position after waiting for followers

## Testing
- `python3 -m py_compile add_texts_comments.py generate_texts.py`

------
https://chatgpt.com/codex/tasks/task_e_685d820560a4832fb9a861f7aca92e22