### PR TITLE
Fix character movement functions

### DIFF
--- a/src/characters.c
+++ b/src/characters.c
@@ -229,9 +229,11 @@ void move_character(u16 nchar, s16 newx, s16 newy)    // Move character with wal
         look_left(nchar, false);
     }
 
-    dprintf(3,"Moving character %d to (%d, %d)\n", nchar, FASTFIX32_FROM_INT(newx), FASTFIX32_FROM_INT(newy));
+    dprintf(3,"Moving character %d to (%d, %d)\n", nchar, newx, newy);
 
-    move_entity(&obj_character[nchar], spr_chr[nchar], newx, newy);
+    fastfix32 newx_fixed = FASTFIX32_FROM_INT(newx);
+    fastfix32 newy_fixed = FASTFIX32_FROM_INT(newy);
+    move_entity(&obj_character[nchar], spr_chr[nchar], newx_fixed, newy_fixed);
     obj_character[nchar].state=STATE_IDLE; // Set state to idle after moving
 }
 


### PR DESCRIPTION
## Summary
- correctly convert `s16` parameters to `fastfix32` in `move_character`
- improve debug message to show plain `s16` coordinates

## Testing
- `python3 -m py_compile add_texts_comments.py generate_texts.py`
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_686668bc0638832f87c533067a900fbb