### PR TITLE
Support fractional movement in move_entity

### DIFF
--- a/src/entity.c
+++ b/src/entity.c
@@ -4,23 +4,26 @@ bool movement_active;    // Whether entity movement is currently allowed
 
 void move_entity(Entity *entity, Sprite *sprite, fastfix32 newx, fastfix32 newy)    // Move entity to new position with smooth animation and shadow updates
 {
-    u16 nchar=CHR_NONE;
+    u16 nchar = CHR_NONE;
     u16 nenemy = ENEMY_NONE;
 
-    s16 target_x = FASTFIX32_TO_INT(newx);
-    s16 target_y = FASTFIX32_TO_INT(newy) - entity->y_size; // Now all calculations are relative to the bottom line, not the upper one
+    fastfix32 target_x = newx;
+    fastfix32 target_y = newy - FASTFIX32_FROM_INT(entity->y_size); // Coordinates relative to sprite top
 
-    s16 x = FASTFIX32_TO_INT(entity->x);
-    s16 y = FASTFIX32_TO_INT(entity->y);
-    s16 dx = target_x - x;
-    s16 dy = target_y - y;
-    s16 sx = dx > 0 ? 1 : -1;
-    s16 sy = dy > 0 ? 1 : -1;
-    s16 err = (abs(dx) > abs(dy) ? abs(dx) : -abs(dy)) / 2;
-    s16 e2;
-    bool old_movement_active=movement_active;
+    fastfix32 x = entity->x;
+    fastfix32 y = entity->y;
+    fastfix32 dx = target_x - x;
+    fastfix32 dy = target_y - y;
+    fastfix32 abs_dx = dx >= 0 ? dx : -dx;
+    fastfix32 abs_dy = dy >= 0 ? dy : -dy;
+    u32 steps = (abs_dx > abs_dy ? abs_dx : abs_dy) >> 16;
+    if (steps == 0) steps = 1;
+    fastfix32 step_x = dx / (fastfix32)steps;
+    fastfix32 step_y = dy / (fastfix32)steps;
+    bool old_movement_active = movement_active;
 
-    dprintf(3,"Moving entity %p to (%d, %d)\n", entity, target_x, target_y);
+    dprintf(3,"Moving entity %p to (%d, %d)\n", entity,
+            FASTFIX32_TO_INT(target_x), FASTFIX32_TO_INT(target_y));
 
     // Check if this entity is a character so we can update its shadow
     for (u16 i = 0; i < MAX_CHR; i++) {
@@ -38,21 +41,24 @@ void move_entity(Entity *entity, Sprite *sprite, fastfix32 newx, fastfix32 newy)
         }
     }
 
-    movement_active=false; // Player can't move while an entity is moving
-    for(;;)
+    movement_active = false; // Player can't move while an entity is moving
+    for (u32 i = 0; i < steps; i++)
     {
-        SPR_setPosition(sprite, x, y);
+        x += step_x;
+        y += step_y;
+        SPR_setPosition(sprite, FASTFIX32_TO_INT(x), FASTFIX32_TO_INT(y));
         if (nchar != CHR_NONE) update_character_shadow(nchar);
         if (nenemy != ENEMY_NONE) update_enemy_shadow(nenemy);
-        entity->x = FASTFIX32_FROM_INT(x);
-        entity->y = FASTFIX32_FROM_INT(y);
+        entity->x = x;
+        entity->y = y;
         next_frame(false);
-
-        if (x == target_x && y == target_y) break;
-
-        e2 = err;
-        if (e2 > -abs(dx)) { err -= abs(dy); x += sx; }
-        if (e2 < abs(dy)) { err += abs(dx); y += sy; }
     }
-    movement_active=old_movement_active;
+
+    // Ensure final position matches target exactly
+    SPR_setPosition(sprite, FASTFIX32_TO_INT(target_x), FASTFIX32_TO_INT(target_y));
+    if (nchar != CHR_NONE) update_character_shadow(nchar);
+    if (nenemy != ENEMY_NONE) update_enemy_shadow(nenemy);
+    entity->x = target_x;
+    entity->y = target_y;
+    movement_active = old_movement_active;
 }


### PR DESCRIPTION
## Summary
- allow move_entity to handle fixed point coordinates

## Testing
- `make` *(fails: No targets specified)*

------
https://chatgpt.com/codex/tasks/task_e_6866fabab6c0832fbac7cbef130a3ecf